### PR TITLE
Fixed isssues that result in errors 

### DIFF
--- a/asmupload.sh
+++ b/asmupload.sh
@@ -45,7 +45,6 @@ fi
 # mentioned within the documentation.
 rm "$STRIPPED_FN.eep.hex"
 rm "$STRIPPED_FN.obj"
-rm "$STRIPPED_FN.cof"
 mv "$STRIPPED_FN.hex" "$OUTPUT_FILE"
 
 # Upload our machine code to the Arduino using avrdude

--- a/asmupload.sh
+++ b/asmupload.sh
@@ -13,6 +13,12 @@ if [[ "$1" == "help" ]] || [[ "$1" == "" ]] || [[ "$2" == "" ]]; then
 	exit 0
 fi
 
+# Check if specified file exists otherwise send an error 
+if [ ! -f "$2" ]; then
+    echo "-- Aborted due to error ($2 doesn't exist)"
+    exit 0
+fi
+
 # Bash oneliner to get the directory the scripts lives in.
 DIR="$(cd ""$(dirname ""${BASH_SOURCE[0]}"")"" && pwd)"
 
@@ -45,6 +51,7 @@ fi
 # mentioned within the documentation.
 rm "$STRIPPED_FN.eep.hex"
 rm "$STRIPPED_FN.obj"
+rm -f "$STRIPPED_FN.cof"
 mv "$STRIPPED_FN.hex" "$OUTPUT_FILE"
 
 # Upload our machine code to the Arduino using avrdude


### PR DESCRIPTION
At the start of script, check if specified .asm or .txt file even exists, since if it goes further down the script it spits out a bunch of errors regarding files that dont exist instead of a singular concise error.

Force delete .cof file that avra sometimes generates, because on macos it always results in:
 ```rm: whatever.txt.cof: No such file or directory``` 
 This removes the error, and in turn confusion about if the code actually uploaded.